### PR TITLE
refactor(badge): ♻️  remove basic badge prefix from storybook args

### DIFF
--- a/src/badge/stories/BadgeBasic.stories.tsx
+++ b/src/badge/stories/BadgeBasic.stories.tsx
@@ -19,7 +19,7 @@ export default {
     preview: createPreviewTabs({ js, ts }),
   },
   argTypes: createControls("badge", {
-    ignore: ["wrapElement", "as", "ref"],
+    ignore: ["wrapElement", "as", "ref", "prefix"],
   }),
 } as Meta;
 


### PR DESCRIPTION
This PR removes the basic badge prefix from storybook args.

Added this PR since the #332 doesn't address this.